### PR TITLE
Feature/switch item view

### DIFF
--- a/components/MyBannerView.vue
+++ b/components/MyBannerView.vue
@@ -1,0 +1,84 @@
+<template>
+    <v-card outlined flat tile elevation="0" class="mx-auto my-0 ">
+        <v-toolbar flat>
+            <v-toolbar-title>{{ title }}</v-toolbar-title>
+        </v-toolbar>
+        <div class="d-flex flex-no-wrap justify-space-between">
+            <v-avatar v-if="imageUrl.length > 0" tile size="90" class="mb-3 ml-3">
+                <v-dialog transition="dialog-bottom-transition" max-width="600">
+                    <template #activator="{ on, attrs }">
+                        <v-img :src="imageUrl" v-bind="attrs" v-on="on"></v-img>
+                    </template>
+                    <template #default="dialog">
+                        <v-card>
+                            <v-img :src="imageUrl" v-bind="attrs" v-on="on"></v-img>
+                            <v-card-actions class="justify-end">
+                                <v-btn text @click="dialog.value = false">Close</v-btn>
+                            </v-card-actions>
+                        </v-card>
+                    </template>
+                </v-dialog>
+            </v-avatar>
+            <div class="mx-3">
+                <div v-if="description.length > 0" class="text-body-2">
+                    {{ description }}
+                </div>
+                <div class="text-overline my-3">{{ date }}</div>
+            </div>
+            <v-card-actions>
+                <v-btn v-if="btnText.length > 0" :color="btnColor" outlined class="mb-0" @click="btnClick">
+                    {{ btnText }}
+                </v-btn>
+            </v-card-actions>
+        </div>
+    </v-card>
+</template>
+
+<script>
+export default {
+    name: 'MyBannerView',
+    props: {
+        imageUrl: {
+            type: String,
+            required: false,
+            default: null
+        },
+        title: {
+            type: String,
+            required: true,
+            default: ""
+        },
+        description: {
+            type: String,
+            required: true,
+            default: ""
+        },
+        date: {
+            type: String,
+            required: true,
+            default: ""
+        },
+        btnText: {
+            type: String,
+            required: false,
+            default: ""
+        },
+        btnColor: {
+            type: String,
+            required: false,
+            default: "gray"
+        },
+    },
+    methods: {
+        btnClick() {
+            this.$emit('onButtonClick');
+        }
+    }
+}
+</script>
+<style>
+v-card-actions {
+    position: absolute;
+    bottom: 0;
+}
+</style>

--- a/pages/rss/_category.vue
+++ b/pages/rss/_category.vue
@@ -55,7 +55,6 @@ export default {
     },
     data() {
         return {
-            listDisplayFlg: false,
             loading: {
                 flg: true,
                 size: 70,
@@ -71,6 +70,14 @@ export default {
         }
     },
     computed: {
+        listDisplayFlg: {
+            get() {
+                return this.$store.getters['rss/getListDisplayFlg']();
+            },
+            set(value) {
+                this.$store.commit('rss/setListDisplayFlg', value);
+            }
+        },
         labelListDisplaySwitch() {
             return this.listDisplayFlg ? "グリッド表示に切替" : "リスト表示に切替"
         }

--- a/pages/rss/_category.vue
+++ b/pages/rss/_category.vue
@@ -6,18 +6,29 @@
         <!--  Error発生時 -->
         <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
         </my-error-view>
-        <v-col v-if="!loading.flg && !error.flg && !listDisplayFlg" class="d-flex flex-wrap">
-            <my-card-view v-for="item in items" :key="item.title" :title="item.title" :description="item.description"
-                :date="item.date" :image-url="item.image" btn-text="詳細をみる" btn-color="blue darken-1"
-                @onButtonClick="detailLink(item)">
-            </my-card-view>
-        </v-col>
-        <v-col v-if="!loading.flg && !error.flg && listDisplayFlg">
-            <my-banner-view v-for="item in items" :key="item.title" :title="item.title" :description="item.description"
-                :date="item.date" :image-url="item.image" btn-text="詳細をみる" btn-color="blue darken-1"
-                @onButtonClick="detailLink(item)">
-            </my-banner-view>
-        </v-col>
+        <v-row v-else-if="items.length > 0">
+            <v-col cols="12">
+                <v-switch v-model="listDisplayFlg" :label="labelListDisplaySwitch">
+                </v-switch>
+            </v-col>
+            <v-col v-if="listDisplayFlg">
+                <my-banner-view v-for="item in items" :key="item.title" :title="item.title"
+                    :description="item.description" :date="item.date" :image-url="item.image" btn-text="詳細をみる"
+                    btn-color="blue darken-1" @onButtonClick="detailLink(item)">
+                </my-banner-view>
+            </v-col>
+            <v-col v-else class="d-flex flex-wrap">
+                <my-card-view v-for="item in items" :key="item.title" :title="item.title"
+                    :description="item.description" :date="item.date" :image-url="item.image" btn-text="詳細をみる"
+                    btn-color="blue darken-1" @onButtonClick="detailLink(item)">
+                </my-card-view>
+            </v-col>
+        </v-row>
+        <v-row v-else>
+            <v-col>
+                <div class="text-h3 mt-3">表示する内容がありません。</div>
+            </v-col>
+        </v-row>
     </v-row>
 </template>
 
@@ -60,6 +71,9 @@ export default {
         }
     },
     computed: {
+        labelListDisplaySwitch() {
+            return this.listDisplayFlg ? "グリッド表示に切替" : "リスト表示に切替"
+        }
     },
     mounted() {
         this.load();

--- a/pages/rss/_category.vue
+++ b/pages/rss/_category.vue
@@ -6,17 +6,23 @@
         <!--  Error発生時 -->
         <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
         </my-error-view>
-        <!-- データ表示 -->
-        <v-col v-else class="d-flex flex-wrap">
+        <v-col v-if="!loading.flg && !error.flg && !listDisplayFlg" class="d-flex flex-wrap">
             <my-card-view v-for="item in items" :key="item.title" :title="item.title" :description="item.description"
                 :date="item.date" :image-url="item.image" btn-text="詳細をみる" btn-color="blue darken-1"
                 @onButtonClick="detailLink(item)">
             </my-card-view>
         </v-col>
+        <v-col v-if="!loading.flg && !error.flg && listDisplayFlg">
+            <my-banner-view v-for="item in items" :key="item.title" :title="item.title" :description="item.description"
+                :date="item.date" :image-url="item.image" btn-text="詳細をみる" btn-color="blue darken-1"
+                @onButtonClick="detailLink(item)">
+            </my-banner-view>
+        </v-col>
     </v-row>
 </template>
 
 <script>
+import MyBannerView from '~/components/MyBannerView'
 import MyCardView from '~/components/MyCardView'
 import MyErrorView from '~/components/MyErrorView'
 import MyLoadingProgress from '~/components/MyLoadingProgress'
@@ -27,6 +33,7 @@ const parseString = require('xml2js').parseString;
 export default {
     name: 'RssListPage',
     components: {
+        MyBannerView,
         MyCardView,
         MyErrorView,
         MyLoadingProgress,
@@ -37,6 +44,7 @@ export default {
     },
     data() {
         return {
+            listDisplayFlg: false,
             loading: {
                 flg: true,
                 size: 70,

--- a/store/rss.js
+++ b/store/rss.js
@@ -1,4 +1,5 @@
 const state = () => ({
+    listDisplayFlg: false, // リスト表示切替フラグ
     rssInfo: [
         {
             name: "はてな（人気）",
@@ -33,6 +34,13 @@ const state = () => ({
     ]
 });
 
+const mutations = {
+    // リスト表示切替フラグを更新
+    setListDisplayFlg(state, value) {
+        state.listDisplayFlg = value;
+    }
+};
+
 const getters = {
     // indexから情報を取得
     getRssInfoFromIndex: state => (index) => {
@@ -45,10 +53,15 @@ const getters = {
     // categoryからindex情報を取得
     getRssInfoIndexFromCategory: state => (category) => {
         return state.rssInfo.findIndex(element => element.category === category);
+    },
+    // リスト表示切替フラグを取得
+    getListDisplayFlg: state => () => {
+        return state.listDisplayFlg;
     }
 };
 
 export default {
     state,
+    mutations,
     getters,
 }


### PR DESCRIPTION
# 概要
switchを使ってリスト表示に切り替えらえるように対応

# 詳細
switchを使って、表示形式を切り替えられるように修正。
switchの値は。storeに保存する。

# キャプチャ
## リスト表示
<img width="700px" alt="スクリーンショット 2022-07-26 19 16 50" src="https://user-images.githubusercontent.com/108524742/180983082-d19b1291-541c-4b49-9496-91b21a0564de.png">

リスト表示の時は画像が小さいので、画像をクリックすると、ダイアログで拡大表示できるようにしてみた。
<img width="700px" alt="スクリーンショット 2022-07-26 19 19 30" src="https://user-images.githubusercontent.com/108524742/180983555-deba2f6b-ac4c-42cd-8513-bce0a1e383da.png">


## グリッド表示
<img width="700px" alt="スクリーンショット 2022-07-26 19 17 03" src="https://user-images.githubusercontent.com/108524742/180983107-b29ad8e8-412d-4c7f-a0bb-95d27a1b89c8.png">
