### PR TITLE
scriptsの内容修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxt",
+    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",


### PR DESCRIPTION
# 概要
node 18.0.0にバージョン上げると実行できなくなったので、scriptsの内容修正。

# 詳細
node 18.0.0にバージョン上げて実行すると、
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ]のエラーがでた。
↓
「export NODE_OPTIONS=--openssl-legacy-provider &&」　を付与すればよいとのこと。