### PR TITLE
jsonplaceholderからデータを取得し、表示するページを作成

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app dark>
     <!-- ■Header -->
-    <v-app-bar color="teal" fixed app dark>
+    <v-app-bar color="primary" fixed app dark>
       <v-toolbar-title v-text="title" />
       <v-spacer />
     </v-app-bar>
@@ -13,7 +13,7 @@
       </v-container>
     </v-main>
     <!-- ■footer -->
-    <v-footer color="teal" app dark>
+    <v-footer color="primary" app dark>
       <span>&copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
   </v-app>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -93,6 +93,9 @@ export default {
           error: colors.deepOrange.accent4,
           success: colors.green.accent3
         }
+      },
+      options: {
+        customProperties: true
       }
     }
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -63,6 +63,10 @@ export default {
       target: 'https://rss.itmedia.co.jp',
       pathRewrite: { '^/apiITMedia/': '' },
     },
+    '/apiJSONplaceholder/': {
+      target: 'https://jsonplaceholder.typicode.com',
+      pathRewrite: { '^/apiJSONplaceholder/': '' },
+    },
   },
 
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify

--- a/pages/jsonplaceholder/posts.vue
+++ b/pages/jsonplaceholder/posts.vue
@@ -1,0 +1,112 @@
+<template>
+    <v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-container v-else-if="items.length > 0">
+            <v-row class="my-3">
+                <v-btn outlined color="primary" @click="detailLink()">API
+                </v-btn>
+            </v-row>
+            <v-row class="my-3">
+                <v-card>
+                    <v-card-title>
+                        Data
+                        <v-spacer></v-spacer>
+                        <v-text-field v-model="search" append-icon="mdi-magnify" label="検索" single-line hide-details>
+                        </v-text-field>
+                    </v-card-title>
+                    <v-data-table :headers="headers" :items="items" :search="search" no-data-text="表示するデータがありません。"
+                        no-results-text="一致するデータがありません。">
+                        <template v-slot:[`item.userId`]="{ item }">
+                            <nuxt-link :to="'/jsonplaceholder/user/' + item.userId">
+                                {{ item.userId }}
+                            </nuxt-link>
+                        </template>
+                    </v-data-table>
+                </v-card>
+            </v-row>
+        </v-container>
+        <v-container v-else>
+            <v-row>
+                <div class="text-h3 mt-3">表示するデータがありません。</div>
+            </v-row>
+        </v-container>
+    </v-row>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+// import MyLoadingProgress from '~/components/MyLoadingProgress'
+
+export default {
+    name: 'JsonPlaceholderPostsPage',
+    components: {
+        MyErrorView,
+        // MyLoadingProgress,
+    },
+    data() {
+        return {
+            search: '',
+            headers: [
+                {
+                    text: 'id', value: 'id',
+                },
+                {
+                    text: 'userId', value: 'userId',
+                },
+                {
+                    text: 'title', value: 'title',
+                },
+                {
+                    text: 'body', value: 'body',
+                },
+            ],
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            items: "jsonplaceholder/getPostItems",
+            loadingFlg: "view/getLoadingFlg",
+        }),
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            getPosts: "jsonplaceholder/getPosts",
+        }),
+        // データを取得する
+        load() {
+            this.initError();
+            this.getPosts().catch((err) => {
+                this.setError(err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        detailLink() {
+            window.open('https://jsonplaceholder.typicode.com/posts', '_blank');
+        }
+    }
+}
+</script>
+

--- a/pages/jsonplaceholder/user/_userId.vue
+++ b/pages/jsonplaceholder/user/_userId.vue
@@ -1,0 +1,93 @@
+<template>
+    <v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-container v-else>
+            <v-row class="my-3">
+                <v-btn outlined color="primary" @click="detailLink()">API
+                </v-btn>
+            </v-row>
+            <v-row>
+                <v-card>
+                    <v-card-title>ユーザ情報</v-card-title>
+                    <v-simple-table dense>
+                        <tbody>
+                            <tr v-for="item in items" :key="item.key">
+                                <td :class="{ header: item.headerFlg }">{{ item.key }}</td>
+                                <td :class="{ header: item.headerFlg }">{{ item.value }}</td>
+                            </tr>
+                        </tbody>
+                    </v-simple-table>
+                </v-card>
+            </v-row>
+        </v-container>
+    </v-row>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
+
+export default {
+    name: 'JsonPlaceholderUserPage',
+    components: {
+        MyErrorView,
+        MyLoadingProgress,
+    },
+    layout: 'default',
+    data() {
+        return {
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            items: "jsonplaceholder/getUserInfos",
+            loadingFlg: "view/getLoadingFlg",
+        }),
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            getUser: "jsonplaceholder/getUser",
+        }),
+        // データを取得する
+        load() {
+            this.initError();
+            this.getUser(this.$route.params.userId).catch((err) => {
+                this.setError(err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        detailLink() {
+            window.open('https://jsonplaceholder.typicode.com/users/' + this.$route.params.userId, '_blank');
+        }
+    }
+}
+</script>
+
+<style>
+td.header {
+    background-color: var(--v-accent-base);
+}
+</style></style>

--- a/pages/rss/_category.vue
+++ b/pages/rss/_category.vue
@@ -7,33 +7,37 @@
         <!--  Error発生時 -->
         <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
         </my-error-view>
-        <v-row v-else-if="items.length > 0">
-            <v-col cols="12">
+        <v-container v-else-if="items.length > 0">
+            <v-row>
                 <v-switch v-model="listDisplayFlg" :label="labelListDisplaySwitch">
                 </v-switch>
-            </v-col>
-            <v-col v-if="listDisplayFlg">
-                <my-banner-view v-for="item in items" :key="item.title" :title="item.title"
-                    :description="item.description" :date="item.date" :image-url="item.image" btn-text="詳細をみる"
-                    btn-color="blue darken-1" @onButtonClick="detailLink(item)">
-                </my-banner-view>
-            </v-col>
-            <v-col v-else class="d-flex flex-wrap">
+            </v-row>
+            <v-row v-if="listDisplayFlg">
+                <v-col>
+                    <my-banner-view v-for="item in items" :key="item.title" :title="item.title"
+                        :description="item.description" :date="item.date" :image-url="item.image" btn-text="詳細をみる"
+                        btn-color="blue darken-1" @onButtonClick="detailLink(item)">
+                    </my-banner-view>
+                </v-col>
+            </v-row>
+            <v-row v-else class="d-flex flex-wrap">
                 <my-card-view v-for="item in items" :key="item.title" :title="item.title"
                     :description="item.description" :date="item.date" :image-url="item.image" btn-text="詳細をみる"
                     btn-color="blue darken-1" @onButtonClick="detailLink(item)">
                 </my-card-view>
-            </v-col>
-        </v-row>
-        <v-row v-else>
+            </v-row>
+        </v-container>
+        <v-container v-else>
             <v-col>
                 <div class="text-h3 mt-3">表示する内容がありません。</div>
             </v-col>
-        </v-row>
+        </v-container>
     </v-row>
 </template>
 
 <script>
+import { mapGetters, mapActions } from "vuex";
+
 import MyBannerView from '~/components/MyBannerView'
 import MyCardView from '~/components/MyCardView'
 import MyErrorView from '~/components/MyErrorView'
@@ -53,7 +57,6 @@ export default {
     },
     data() {
         return {
-            loadingFlg: true,
             error: {
                 flg: false,
                 title: "エラー",
@@ -62,15 +65,21 @@ export default {
         }
     },
     computed: {
+        ...mapGetters({
+            loadingFlg: "view/getLoadingFlg",
+            getRssResultData: "rss/getRssResultData",
+            getListDisplayFlg: "rss/getListDisplayFlg"
+        }),
         items() {
-            return this.$store.getters['rss/getRssResultData'](this.$route.params.category);
+            console.log("computed->items");
+            return this.getRssResultData(this.$route.params.category);
         },
         listDisplayFlg: {
             get() {
-                return this.$store.getters['rss/getListDisplayFlg']();
+                return this.getListDisplayFlg;
             },
             set(value) {
-                this.$store.commit('rss/setListDisplayFlg', value);
+                this.updateListDisplayFlg(value);
             }
         },
         labelListDisplaySwitch() {
@@ -81,15 +90,17 @@ export default {
         this.load();
     },
     methods: {
+        ...mapActions({
+            updateLoadingFlg: "view/updateLoadingFlg",
+            updateListDisplayFlg: "rss/updateListDisplayFlg",
+            getRssData: "rss/getRssData"
+        }),
         // データを取得する
         load() {
             const category = this.$route.params.category;
-            this.loadingFlg = true;
             this.initError();
-            this.$store.dispatch('rss/getRssData', category).catch((err) => {
+            this.getRssData(category).catch((err) => {
                 this.setError(err.errorMessage);
-            }).finally(() => {
-                this.loadingFlg = false;
             });
         },
         initError() {

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,20 +1,27 @@
-export default function ({ $axios, redirect }) {
+export default function ({ $axios, store, redirect }) {
 
     $axios.defaults.timeout = 100000;
 
     $axios.onRequest((config) => {
-        // console.log('Making request to ' + JSON.stringify(config));
+        store.commit("view/setLoadingFlg", true);
     });
 
     $axios.onResponse(response => {
+        store.commit("view/setLoadingFlg", false);
         return Promise.resolve(response);
     });
 
     $axios.onError((error) => {
+        store.commit("view/setLoadingFlg", false);
         const code = parseInt(error.response && error.response.status)
         if (code === 400) {
             redirect('/400')
         }
+        return Promise.reject(error.response);
+    });
+
+    $axios.onResponseError((error) => {
+        store.commit("view/setLoadingFlg", false);
         return Promise.reject(error.response);
     });
 }

--- a/store/jsonplaceholder/index.js
+++ b/store/jsonplaceholder/index.js
@@ -1,0 +1,87 @@
+/* eslint-disable object-shorthand */
+const state = () => ({
+    postItems: [],
+    userInfos: []
+});
+
+const mutations = {
+    /**
+     * postItemsデータを更新する
+     **/
+    setPostItems(state, value) {
+        state.postItems = value === undefined ? [] : value;
+    },
+    /**
+     * userInfosデータを更新する
+     **/
+    setUserInfos(state, value) {
+        state.userInfos = value === undefined ? [] : value;
+    },
+};
+
+const getters = {
+    /**
+     * postItemsデータを取得する
+     **/
+    getPostItems(state) {
+        return state.postItems;
+    },
+    /**
+     * userInfosデータを取得する
+     **/
+    getUserInfos(state) {
+        return state.userInfos;
+    },
+};
+
+const actions = {
+    /**
+     * Postsデータを取得する
+     **/
+    async getPosts({ commit }) {
+        return await this.$axios.get("/apiJSONplaceholder/posts")
+            .then(response => {
+                commit('setPostItems', response.data);
+            });
+    },
+    /**
+    * Userデータを取得する
+    **/
+    async getUser({ commit, dispatch }, userId) {
+        return await this.$axios.get("/apiJSONplaceholder/users/" + userId)
+            .then(response => {
+                const tmpInfos = [];
+                dispatch('parseUser', { data: response.data, items: tmpInfos });
+                commit('setUserInfos', tmpInfos);
+            });
+    },
+    /**
+    * Userデータを整形する
+    **/
+    parseUser({ dispatch }, { data, items }) {
+        for (const key in data) {
+            if (typeof data[key] === 'object') {
+                items.push({
+                    headerFlg: true,
+                    key: key,
+                    value: ''
+                });
+                dispatch('parseUser', { data: data[key], items: items });
+            } else {
+                items.push({
+                    headerFlg: false,
+                    key: key,
+                    value: data[key]
+                });
+            }
+        }
+    },
+
+};
+
+export default {
+    state,
+    mutations,
+    getters,
+    actions,
+}

--- a/store/rss/index.js
+++ b/store/rss/index.js
@@ -15,13 +15,15 @@ const mutations = {
     },
     // リスト表示切替フラグを更新
     setRssResultData(state, { category, value }) {
-        state.rssResultData[category] = value === undefined ? [] : value;
+        const tmpObj = JSON.parse(JSON.stringify(state.rssResultData));
+        tmpObj[category] = value;
+        state.rssResultData = tmpObj;
     }
 };
 
 const getters = {
     // リスト表示切替フラグを取得
-    getListDisplayFlg: state => () => {
+    getListDisplayFlg(state) {
         return state.listDisplayFlg;
     },
 
@@ -29,15 +31,19 @@ const getters = {
      * categoryに合わせた結果を取得する
      **/
     getRssResultData: state => (category) => {
-        if (state.rssResultData[category] === undefined) {
-            return [];
-        } else {
+        if (Array.isArray(state.rssResultData[category])) {
             return state.rssResultData[category];
+        } else {
+            return [];
         }
     }
 };
 
 const actions = {
+    updateListDisplayFlg({ commit }, value) {
+        commit('setListDisplayFlg', value);
+    },
+
     /**
      * RSSデータを取得する
      **/
@@ -50,8 +56,8 @@ const actions = {
             .then(response => {
                 parseString(response.data, (err, result) => {
                     dispatch('parse', { err: err, category: category, json: result });
+                    return result;
                 });
-                return response;
             });
     },
     /**

--- a/store/view/index.js
+++ b/store/view/index.js
@@ -1,0 +1,35 @@
+/* eslint-disable object-shorthand */
+/* eslint-disable no-empty-pattern */
+const state = () => ({
+    loadingFlg: true, // loading中フラグ
+});
+
+const mutations = {
+    // loading中フラグを更新
+    setLoadingFlg(state, value) {
+        state.loadingFlg = value;
+    }
+};
+
+const getters = {
+    // loading中フラグを取得
+    getLoadingFlg(state) {
+        return state.loadingFlg;
+    },
+};
+
+const actions = {
+    /**
+     * loading中フラグを更新する
+     **/
+    updateLoadingFlg({ commit }, value) {
+        return commit('setLoadingFlg', value);
+    },
+};
+
+export default {
+    state,
+    mutations,
+    getters,
+    actions,
+}


### PR DESCRIPTION
# 概要
jsonplaceholder（https://jsonplaceholder.typicode.com/）からデータを取得し、表示するページを作成

# 詳細
- 以下ページを新規作成
    - jsonplaceholderのpostsデータの一覧表示ページ
    - jsonplaceholderのpostsデータのユーザ情報表示ページ
- rss表示ページの処理修正
    - mapGetter, mapActionsを使用
    - ページレイアウト一部修正
   
# キャプチャ
<img width="800px" alt="スクリーンショット 2022-08-04 0 14 23" src="https://user-images.githubusercontent.com/108524742/182644712-5f7262db-06f1-432a-9d57-0c1951818a39.png">

<img width="800px" alt="スクリーンショット 2022-08-04 0 14 08" src="https://user-images.githubusercontent.com/108524742/182644702-adb5a8af-edd9-439d-a870-991cd0aee279.png">
