### PR TITLE
jsonplaceholderのtodos表示用と、albums関連の表示用ページ追加

### DIFF
--- a/components/MyPhotoCardListView.vue
+++ b/components/MyPhotoCardListView.vue
@@ -1,0 +1,64 @@
+<template>
+    <v-container>
+        <v-row class="my-3">
+            <v-text-field v-model="search" append-icon="mdi-magnify" label="検索" single-line hide-details>
+            </v-text-field>
+        </v-row>
+        <v-row v-if="filteredItems.length > 0" class="d-flex flex-wrap my-3">
+            <v-card v-for="item in filteredItems" :key="item.title" class="mx-auto mb-6" max-width="200" outlined>
+                <v-dialog transition="dialog-bottom-transition" max-width="600">
+                    <template #activator="{ on, attrs }">
+                        <v-img :src="item.url" v-bind="attrs" v-on="on" class="white--text align-end"
+                            gradient="to bottom, rgba(0,0,0,.1), rgba(0,0,0,.5)">
+                            <v-card-title v-text="item.id"></v-card-title>
+                            <v-card-subtitle v-text="item.title"></v-card-subtitle>
+                        </v-img>
+                    </template>
+                    <template #default="dialog">
+                        <v-card>
+                            <v-card-title v-text="item.title"></v-card-title>
+                            <v-img :src="item.url"></v-img>
+                            <v-card-actions class="justify-end">
+                                <v-btn text @click="dialog.value = false">Close</v-btn>
+                            </v-card-actions>
+                        </v-card>
+                    </template>
+                </v-dialog>
+            </v-card>
+        </v-row>
+        <v-row v-else>
+            <div class="text-h4">表示するデータがありません。</div>
+        </v-row>
+    </v-container>
+</template>
+
+<script>
+export default {
+    name: 'MyPhotoCardListView',
+    props: {
+        items: {
+            type: Array,
+            required: false,
+            default: () => []
+        },
+    },
+    data() {
+        return {
+            search: '',
+        }
+    },
+    computed: {
+        filteredItems() {
+            if (this.items.length === 0 || this.search.length === 0) {
+                return this.items;
+            }
+            return this.items.filter(item => String(item.id).includes(this.search) || (item.title.includes(this.search)));
+        }
+    }
+}
+</script>
+<style scoped>
+.v-text-field {
+    max-width: 500px;
+}
+</style>

--- a/components/MyPhotoListView.vue
+++ b/components/MyPhotoListView.vue
@@ -1,0 +1,60 @@
+<template>
+    <v-row class="my-3">
+        <v-card>
+            <v-card-title>
+                Photos LIST
+                <v-spacer></v-spacer>
+                <v-text-field v-model="search" append-icon="mdi-magnify" label="検索" single-line hide-details>
+                </v-text-field>
+            </v-card-title>
+            <v-data-table :headers="headers" :items="items" :search="search" no-data-text="表示するデータがありません。"
+                no-results-text="表示するデータがありません。">
+                <template v-slot:[`item.thumbnailUrl`]="{ item }">
+                    <v-dialog transition="dialog-bottom-transition" max-width="600">
+                        <template #activator="{ on, attrs }">
+                            <v-img :src="item.thumbnailUrl" v-bind="attrs" v-on="on"></v-img>
+                        </template>
+                        <template #default="dialog">
+                            <v-card>
+                                <v-card-title v-text="item.title"></v-card-title>
+                                <v-img :src="item.url"></v-img>
+                                <v-card-actions class="justify-end">
+                                    <v-btn text @click="dialog.value = false">Close</v-btn>
+                                </v-card-actions>
+                            </v-card>
+                        </template>
+                    </v-dialog>
+                </template>
+            </v-data-table>
+        </v-card>
+    </v-row>
+</template>
+
+<script>
+export default {
+    name: 'MyPhotoListView',
+    props: {
+        items: {
+            type: Array,
+            required: false,
+            default: () => []
+        },
+    },
+    data() {
+        return {
+            search: '',
+            headers: [
+                {
+                    text: 'image', value: 'thumbnailUrl',
+                },
+                {
+                    text: 'id', value: 'id',
+                },
+                {
+                    text: 'title', value: 'title',
+                }
+            ],
+        }
+    },
+}
+</script>

--- a/pages/jsonplaceholder/albums/_albumId.vue
+++ b/pages/jsonplaceholder/albums/_albumId.vue
@@ -1,0 +1,106 @@
+<template>
+    <v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-container v-else-if="item.album !== undefined">
+            <v-row class="my-3">
+                <v-btn outlined color="primary" @click="detailAlbumLink()">album API</v-btn>
+                <v-btn outlined color="primary" @click="detailPhotosLink()">Photo API</v-btn>
+            </v-row>
+            <div class="text-h3">{{ item.album.title }}</div>
+            <v-row>
+                <v-switch v-model="listDisplayFlg" :label="labelListDisplaySwitch">
+                </v-switch>
+            </v-row>
+            <my-photo-list-view v-if="listDisplayFlg" :items="item.photos"></my-photo-list-view>
+            <my-photo-card-list-view v-else :items="item.photos"></my-photo-card-list-view>
+        </v-container>
+        <v-container v-else>
+            <v-row>
+                <div class="text-h4 mt-3">表示するデータがありません。</div>
+            </v-row>
+        </v-container>
+    </v-row>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
+import MyPhotoListView from '~/components/MyPhotoListView'
+import MyPhotoCardListView from '~/components/MyPhotoCardListView'
+
+export default {
+    name: 'JsonPlaceholderTodosPage',
+    components: {
+        MyErrorView,
+        MyLoadingProgress,
+        MyPhotoListView,
+        MyPhotoCardListView,
+    },
+    data() {
+        return {
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            loadingFlg: "view/getLoadingFlg",
+            item: "jsonplaceholder/getPhotoItem",
+            getListDisplayFlg: "jsonplaceholder/getListDisplayFlg"
+        }),
+        listDisplayFlg: {
+            get() {
+                return this.getListDisplayFlg;
+            },
+            set(value) {
+                this.updateListDisplayFlg(value);
+            }
+        },
+        labelListDisplaySwitch() {
+            return this.listDisplayFlg ? "グリッド表示に切替" : "リスト表示に切替"
+        }
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            getPhotos: "jsonplaceholder/getPhotos",
+            updateListDisplayFlg: "jsonplaceholder/updateListDisplayFlg",
+        }),
+        // データを取得する
+        load() {
+            this.initError();
+            this.getPhotos(this.$route.params.albumId).catch((err) => {
+                this.setError(err === undefined ? "" : err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        detailAlbumLink() {
+            window.open('https://jsonplaceholder.typicode.com/albums/' + this.$route.params.albumId, '_blank');
+        },
+        // 外部サイトを開く
+        detailPhotosLink() {
+            window.open('https://jsonplaceholder.typicode.com/photos?albumId=' + this.$route.params.albumId, '_blank');
+        }
+    }
+}
+</script>

--- a/pages/jsonplaceholder/albums/index.vue
+++ b/pages/jsonplaceholder/albums/index.vue
@@ -1,0 +1,113 @@
+<template>
+    <v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-container v-else-if="items.length > 0">
+            <v-row class="my-3">
+                <v-btn outlined color="primary" @click="detailLink()">API
+                </v-btn>
+            </v-row>
+            <v-row class="my-3">
+                <v-card>
+                    <v-card-title>
+                        Albums LIST
+                        <v-spacer></v-spacer>
+                        <v-text-field v-model="search" append-icon="mdi-magnify" label="検索" single-line hide-details>
+                        </v-text-field>
+                    </v-card-title>
+                    <v-data-table :headers="headers" :items="items" :search="search" no-data-text="表示するデータがありません。"
+                        no-results-text="一致するデータがありません。">
+                        <template v-slot:[`item.userId`]="{ item }">
+                            <nuxt-link :to="'/jsonplaceholder/user/' + item.userId">
+                                {{ item.userId }}
+                            </nuxt-link>
+                        </template>
+                        <template v-slot:[`item.title`]="{ item }">
+                            <nuxt-link :to="'/jsonplaceholder/albums/' + item.id">
+                                {{ item.title }}
+                            </nuxt-link>
+                        </template>
+                    </v-data-table>
+                </v-card>
+            </v-row>
+        </v-container>
+        <v-container v-else>
+            <v-row>
+                <div class="text-h3 mt-3">表示するデータがありません。</div>
+            </v-row>
+        </v-container>
+    </v-row>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
+
+export default {
+    name: 'JsonPlaceholderAlbumsListPage',
+    components: {
+        MyErrorView,
+        MyLoadingProgress,
+    },
+    data() {
+        return {
+            search: '',
+            headers: [
+                {
+                    text: 'id', value: 'id',
+                },
+                {
+                    text: 'userId', value: 'userId',
+                },
+                {
+                    text: 'title', value: 'title',
+                }
+            ],
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            items: "jsonplaceholder/getAlbumItems",
+            loadingFlg: "view/getLoadingFlg",
+        }),
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            getAlbums: "jsonplaceholder/getAlbums",
+        }),
+        // データを取得する
+        load() {
+            this.initError();
+            this.getAlbums().catch((err) => {
+                this.setError(err === undefined ? "" : err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        detailLink() {
+            window.open('https://jsonplaceholder.typicode.com/albums', '_blank');
+        }
+    }
+}
+</script>

--- a/pages/jsonplaceholder/posts.vue
+++ b/pages/jsonplaceholder/posts.vue
@@ -42,13 +42,13 @@
 <script>
 import { mapGetters, mapActions } from "vuex";
 import MyErrorView from '~/components/MyErrorView'
-// import MyLoadingProgress from '~/components/MyLoadingProgress'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
 
 export default {
     name: 'JsonPlaceholderPostsPage',
     components: {
         MyErrorView,
-        // MyLoadingProgress,
+        MyLoadingProgress,
     },
     data() {
         return {
@@ -91,7 +91,7 @@ export default {
         load() {
             this.initError();
             this.getPosts().catch((err) => {
-                this.setError(err.errorMessage);
+                this.setError(err === undefined ? "" : err.errorMessage);
             });
         },
         initError() {
@@ -109,4 +109,3 @@ export default {
     }
 }
 </script>
-

--- a/pages/jsonplaceholder/todos.vue
+++ b/pages/jsonplaceholder/todos.vue
@@ -1,0 +1,114 @@
+<template>
+    <v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-container v-else-if="items.length > 0">
+            <v-row class="my-3">
+                <v-btn outlined color="primary" @click="detailLink()">API
+                </v-btn>
+            </v-row>
+            <v-row class="my-3">
+                <v-card>
+                    <v-card-title>
+                        TODO LIST
+                        <v-spacer></v-spacer>
+                        <v-text-field v-model="search" append-icon="mdi-magnify" label="検索" single-line hide-details>
+                        </v-text-field>
+                    </v-card-title>
+                    <v-data-table :headers="headers" :items="items" :search="search" no-data-text="表示するデータがありません。"
+                        no-results-text="一致するデータがありません。">
+                        <template v-slot:[`item.userId`]="{ item }">
+                            <nuxt-link :to="'/jsonplaceholder/user/' + item.userId">
+                                {{ item.userId }}
+                            </nuxt-link>
+                        </template>
+                        <template v-slot:[`item.completed`]="{ item }">
+                            <v-simple-checkbox v-model="item.completed" disabled></v-simple-checkbox>
+                        </template>
+                    </v-data-table>
+                </v-card>
+            </v-row>
+        </v-container>
+        <v-container v-else>
+            <v-row>
+                <div class="text-h3 mt-3">表示するデータがありません。</div>
+            </v-row>
+        </v-container>
+    </v-row>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
+
+export default {
+    name: 'JsonPlaceholderTodosPage',
+    components: {
+        MyErrorView,
+        MyLoadingProgress,
+    },
+    data() {
+        return {
+            search: '',
+            headers: [
+                {
+                    text: 'id', value: 'id',
+                },
+                {
+                    text: 'userId', value: 'userId',
+                },
+                {
+                    text: 'title', value: 'title',
+                },
+                {
+                    text: 'completed', value: 'completed',
+                },
+            ],
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            items: "jsonplaceholder/getTodoItems",
+            loadingFlg: "view/getLoadingFlg",
+        }),
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            getTodos: "jsonplaceholder/getTodos",
+        }),
+        // データを取得する
+        load() {
+            this.initError();
+            this.getTodos().catch((err) => {
+                this.setError(err === undefined ? "" : err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        detailLink() {
+            window.open('https://jsonplaceholder.typicode.com/todos', '_blank');
+        }
+    }
+}
+</script>

--- a/pages/jsonplaceholder/user/_userId.vue
+++ b/pages/jsonplaceholder/user/_userId.vue
@@ -90,4 +90,4 @@ export default {
 td.header {
     background-color: var(--v-accent-base);
 }
-</style></style>
+</style>

--- a/pages/rss/_category.vue
+++ b/pages/rss/_category.vue
@@ -71,7 +71,6 @@ export default {
             getListDisplayFlg: "rss/getListDisplayFlg"
         }),
         items() {
-            console.log("computed->items");
             return this.getRssResultData(this.$route.params.category);
         },
         listDisplayFlg: {

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -17,11 +17,11 @@ export default function ({ $axios, store, redirect }) {
         if (code === 400) {
             redirect('/400')
         }
-        return Promise.reject(error.response);
+        return Promise.reject(error);
     });
 
     $axios.onResponseError((error) => {
         store.commit("view/setLoadingFlg", false);
-        return Promise.reject(error.response);
+        return Promise.reject(error);
     });
 }

--- a/store/jsonplaceholder/index.js
+++ b/store/jsonplaceholder/index.js
@@ -6,6 +6,8 @@ const state = () => ({
     todoItems: [],  // todoデータ
     albumItems: [], // アルバム
     photoItem: {},  // photoデータ
+    /** 表示管理用 **/
+    listDisplayFlg: false, // リスト表示切替フラグ
 });
 
 const mutations = {
@@ -42,6 +44,10 @@ const mutations = {
             photos: photoItems === undefined ? [] : photoItems
         };
     },
+    // リスト表示切替フラグを更新
+    setListDisplayFlg(state, value) {
+        state.listDisplayFlg = value;
+    },
 };
 
 const getters = {
@@ -74,6 +80,10 @@ const getters = {
     **/
     getPhotoItem(state, value) {
         return state.photoItem;
+    },
+    // リスト表示切替フラグを取得
+    getListDisplayFlg(state) {
+        return state.listDisplayFlg;
     },
 };
 
@@ -156,6 +166,12 @@ const actions = {
                 photoItems: responses[1].data
             });
         });
+    },
+    /**
+    * リスト表示切替フラグを更新する
+    **/
+    updateListDisplayFlg({ commit }, value) {
+        commit('setListDisplayFlg', value);
     },
 };
 

--- a/store/jsonplaceholder/index.js
+++ b/store/jsonplaceholder/index.js
@@ -1,7 +1,9 @@
 /* eslint-disable object-shorthand */
 const state = () => ({
-    postItems: [],
-    userInfos: []
+    /** データ **/
+    postItems: [],  // postデータ
+    userInfos: [],  // ユーザ情報
+    todoItems: [],  // todoデータ
 });
 
 const mutations = {
@@ -17,6 +19,12 @@ const mutations = {
     setUserInfos(state, value) {
         state.userInfos = value === undefined ? [] : value;
     },
+    /**
+     * todoItemsデータを更新する
+     **/
+    setTodoItems(state, value) {
+        state.todoItems = value === undefined ? [] : value;
+    },
 };
 
 const getters = {
@@ -31,6 +39,12 @@ const getters = {
      **/
     getUserInfos(state) {
         return state.userInfos;
+    },
+    /**
+     * todoItemsデータを取得する
+     **/
+    getTodoItems(state) {
+        return state.todoItems;
     },
 };
 
@@ -76,7 +90,15 @@ const actions = {
             }
         }
     },
-
+    /**
+    * Todosデータを取得する
+    **/
+    async getTodos({ commit }) {
+        return await this.$axios.get("/apiJSONplaceholder/todos")
+            .then(response => {
+                commit('setTodoItems', response.data);
+            });
+    },
 };
 
 export default {

--- a/store/jsonplaceholder/index.js
+++ b/store/jsonplaceholder/index.js
@@ -4,6 +4,8 @@ const state = () => ({
     postItems: [],  // postデータ
     userInfos: [],  // ユーザ情報
     todoItems: [],  // todoデータ
+    albumItems: [], // アルバム
+    photoItem: {},  // photoデータ
 });
 
 const mutations = {
@@ -25,6 +27,21 @@ const mutations = {
     setTodoItems(state, value) {
         state.todoItems = value === undefined ? [] : value;
     },
+    /**
+     * albumItemsデータを更新する
+     **/
+    setAlbumItems(state, value) {
+        state.albumItems = value === undefined ? [] : value;
+    },
+    /**
+    * photoItemデータを更新する
+    **/
+    setPhotoItem(state, { albumInfo, photoItems }) {
+        state.photoItem = {
+            album: albumInfo === undefined ? {} : albumInfo,
+            photos: photoItems === undefined ? [] : photoItems
+        };
+    },
 };
 
 const getters = {
@@ -45,6 +62,18 @@ const getters = {
      **/
     getTodoItems(state) {
         return state.todoItems;
+    },
+    /**
+     * albumItemsデータを取得する
+     **/
+    getAlbumItems(state) {
+        return state.albumItems;
+    },
+    /**
+    * photoItemデータを取得する
+    **/
+    getPhotoItem(state, value) {
+        return state.photoItem;
     },
 };
 
@@ -98,6 +127,35 @@ const actions = {
             .then(response => {
                 commit('setTodoItems', response.data);
             });
+    },
+    /**
+    * Albumsデータを取得する
+    **/
+    async getAlbums({ commit }) {
+        return await this.$axios.get("/apiJSONplaceholder/albums")
+            .then(response => {
+                commit('setAlbumItems', response.data);
+            });
+    },
+    /**
+    * Photosデータを取得する
+    **/
+    async getPhotos({ commit }, albumId) {
+        return await Promise.all(
+            [
+                this.$axios.get("/apiJSONplaceholder/albums/" + albumId),
+                this.$axios.get("/apiJSONplaceholder/photos", {
+                    params: {
+                        albumId: albumId
+                    }
+                }),
+            ]
+        ).then(responses => {
+            commit('setPhotoItem', {
+                albumInfo: responses[0].data,
+                photoItems: responses[1].data
+            });
+        });
     },
 };
 


### PR DESCRIPTION
# 概要
Todo一覧ページ、アルバム一覧ページを追加

# 詳細
以下のAPIの情報を表示するページを追加
- Todo
    - API : TODO一覧ー＞https://jsonplaceholder.typicode.com/todos
- アルバム関連
    - API：アルバム一覧ー＞https://jsonplaceholder.typicode.com/albums
    - API：写真一覧ー＞https://jsonplaceholder.typicode.com/photos?albumId=x

# キャプチャ
## TODO一覧ページ
<img width="800" alt="スクリーンショット 2022-08-04 18 04 54" src="https://user-images.githubusercontent.com/108524742/182808894-ed57b18e-6181-4cb0-ba10-eee8eec63edc.png">

## アルバム一覧ページ
<img width="800" alt="スクリーンショット 2022-08-04 18 05 12" src="https://user-images.githubusercontent.com/108524742/182808912-46601fec-ba26-4464-bc64-b8c69cea07da.png">

## 写真一覧ページ
### 写真グリッド表示
<img width="800" alt="スクリーンショット 2022-08-04 18 05 22" src="https://user-images.githubusercontent.com/108524742/182808915-027a966d-ec64-4364-b4ec-f40f2961c883.png">
### 写真リスト表示
<img width="800" alt="スクリーンショット 2022-08-04 18 05 32" src="https://user-images.githubusercontent.com/108524742/182808922-44c49787-2592-41a8-ac02-acbb5c6a3219.png">

### 写真表示ダイアログ
<img width="800" alt="スクリーンショット 2022-08-04 18 05 39" src="https://user-images.githubusercontent.com/108524742/182808923-8718e40b-83a8-4d43-bd73-9a99e049e32a.png">
