### PR TITLE
気象庁から天気予報情報を取得し、表示するページを追加

### DIFF
--- a/components/MyWeatherInfoView.vue
+++ b/components/MyWeatherInfoView.vue
@@ -1,0 +1,60 @@
+<template>
+    <v-row v-if="weatherInfo !== undefined">
+        <!-- -->
+        <v-col v-if="weatherInfo.forecast !== undefined" cols="12" class="my-2">
+            <div class="text-h6">■天気</div>
+            <div class="text-overline"> {{ weatherInfo.forecast.datetime }} 更新</div>
+            <div v-for="areaInfo in weatherInfo.forecast.areas" :key="areaInfo.areaName">
+                <div class="text-subtitle-1 my-3">●{{ areaInfo.areaName }}</div>
+                <v-row class="d-flex flex-wrap">
+                    <v-card v-for="weatherInfo in areaInfo.weatherInfos" :key="weatherInfo.date" min-width="300"
+                        max-width="350" class="mx-3 my-3">
+                        <v-card-title>□{{ weatherInfo.date }}</v-card-title>
+                        <v-img v-if="weatherInfo.weatherImageUrl.length > 0" width="100"
+                            :src="weatherInfo.weatherImageUrl">
+                        </v-img>
+                        <v-card-subtitle>{{ weatherInfo.weather }}</v-card-subtitle>
+                        <v-card-text>
+                            <div><strong>・風</strong></div>
+                            <div class="text-body-2">{{ weatherInfo.wind }}</div>
+                            <div><strong>・波</strong></div>
+                            <div class="text-body-2">{{ weatherInfo.wave }}</div>
+                        </v-card-text>
+                    </v-card>
+                </v-row>
+            </div>
+        </v-col>
+        <!-- 概要 -->
+        <v-col v-if="weatherInfo.overview !== undefined" cols="12" class="mx-auto my-2">
+            <div class="text-h6">■天気概要</div>
+            <div class="text-body2"> {{ weatherInfo.overview.text }} </div>
+            <div class="text-overline"> {{ weatherInfo.overview.datetime }} </div>
+        </v-col>
+        <!-- 週間概要 -->
+        <v-col v-if="weatherInfo.overviewWeek !== undefined" cols="12" class="mx-auto my-2">
+            <div class="text-h6">■週間天気予報</div>
+            <div class="text-body2"> {{ weatherInfo.overviewWeek.text }} </div>
+            <div class="text-overline"> {{ weatherInfo.overviewWeek.datetime }} </div>
+        </v-col>
+        <!-- warining -->
+        <v-col v-if="weatherInfo.warning !== undefined" cols="12" class="mx-auto my-2">
+            <div class="text-h6">■注意情報</div>
+            <div class="text-body2"> {{ weatherInfo.warning.text }} </div>
+            <div class="text-overline"> {{ weatherInfo.warning.datetime }} </div>
+        </v-col>
+    </v-row>
+</template>
+
+<script>
+export default {
+    name: 'MyWeatherInfoView',
+    props: {
+        // eslint-disable-next-line vue/require-prop-types
+        weatherInfo: {
+            type: Object,
+            required: false,
+            default: () => { }
+        },
+    }
+}
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -29,6 +29,7 @@ export default {
     '~/plugins/axios.js',
     '~/plugins/days.js',
     '~/plugins/dayformat.js',
+    '~/plugins/weather.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
@@ -75,6 +76,10 @@ export default {
     '/apiConnpass/': {
       target: 'https://connpass.com/',
       pathRewrite: { '^/apiConnpass/': '' },
+    },
+    '/apiWeather/': {
+      target: 'https://www.jma.go.jp/',
+      pathRewrite: { '^/apiWeather/': '' },
     },
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -74,6 +74,21 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row>
+      <v-col cols="6">
+        <v-card>
+          <v-card-title>天気情報表示</v-card-title>
+          <v-card-subtitle>「気象庁」のデータを取得→表示したページ。</v-card-subtitle>
+          <v-card-text>
+            <ol class="mx-y">
+              <li>
+                <router-link to="/weather/selectarea">天気情報表示ページ</router-link>
+              </li>
+            </ol>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 

--- a/pages/weather/area/_areaId.vue
+++ b/pages/weather/area/_areaId.vue
@@ -75,8 +75,8 @@ import { mapGetters, mapActions } from "vuex";
 
 export default {
     name: 'WeatherAreaPage',
-    validate({ params }) {
-        return params.areaId !== undefined && this.$getWeatherInfo(params.areaId) !== undefined;
+    validate({ app, params }) {
+        return params.areaId !== undefined && app.$getWeatherAreaInfo(params.areaId) !== undefined;
     },
     data() {
         return {

--- a/pages/weather/area/_areaId.vue
+++ b/pages/weather/area/_areaId.vue
@@ -1,0 +1,138 @@
+<template>
+    <v-container>
+        <v-row>
+            <v-col>
+                <div class="text-h4 mt-3">天気予報表示</div>
+                <div class="text-h6 mt-3">「気象庁」のJSONを使用して、天気予報情報を表示します。</div>
+                <v-btn outlined color="primary" class="my-3" @click="apiLink">気象庁</v-btn>
+            </v-col>
+        </v-row>
+        <v-row>
+            <v-col>
+                <div class="text-h6 mt-3">{{ weatherAreaInfo }}</div>
+            </v-col>
+        </v-row>
+        <!-- 読み込み時 -->
+        <my-loading-progress v-if='loadingFlg' :color="$const.loadingProgress.color"
+            :width="$const.loadingProgress.width" :size="$const.loadingProgress.size">
+        </my-loading-progress>
+        <!--  Error発生時 -->
+        <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
+        </my-error-view>
+        <v-row v-else-if="weatherInfo !== undefined">
+            <!-- -->
+            <v-col v-if="weatherInfo.forecast !== undefined" cols="12" class="my-2">
+                <div class="text-h6">■天気</div>
+                <div class="text-overline"> {{ weatherInfo.forecast.datetime }} 更新</div>
+                <div v-for="areaInfo in weatherInfo.forecast.areas" :key="areaInfo.areaName">
+                    <div class="text-subtitle-1 my-3">●{{ areaInfo.areaName }}</div>
+                    <v-row class="d-flex flex-wrap">
+                        <v-card v-for="weatherInfo in areaInfo.weatherInfos" :key="weatherInfo.date" min-width="300"
+                            max-width="350" class="mx-3 my-3">
+                            <v-card-title>□{{ weatherInfo.date }}</v-card-title>
+                            <v-img v-if="weatherInfo.weatherImageUrl.length > 0" width="100"
+                                :src="weatherInfo.weatherImageUrl">
+                            </v-img>
+                            <v-card-subtitle>{{ weatherInfo.weather }}</v-card-subtitle>
+                            <v-card-text>
+                                <div><strong>・風</strong></div>
+                                <div class="text-body-2">{{ weatherInfo.wind }}</div>
+                                <div><strong>・波</strong></div>
+                                <div class="text-body-2">{{ weatherInfo.wave }}</div>
+                            </v-card-text>
+                        </v-card>
+                    </v-row>
+                </div>
+            </v-col>
+
+            <!-- 概要 -->
+            <v-col v-if="weatherInfo.overview !== undefined" cols="12" class="mx-auto my-2">
+                <div class="text-h6">■天気概要</div>
+                <div class="text-body2"> {{ weatherInfo.overview.text }} </div>
+                <div class="text-overline"> {{ weatherInfo.overview.datetime }} </div>
+            </v-col>
+            <!-- 週間概要 -->
+            <v-col v-if="weatherInfo.overviewWeek !== undefined" cols="12" class="mx-auto my-2">
+                <div class="text-h6">■週間天気予報</div>
+                <div class="text-body2"> {{ weatherInfo.overviewWeek.text }} </div>
+                <div class="text-overline"> {{ weatherInfo.overviewWeek.datetime }} </div>
+            </v-col>
+            <!-- warining -->
+            <v-col v-if="weatherInfo.warning !== undefined" cols="12" class="mx-auto my-2">
+                <div class="text-h6">■注意情報</div>
+                <div class="text-body2"> {{ weatherInfo.warning.text }} </div>
+                <div class="text-overline"> {{ weatherInfo.warning.datetime }} </div>
+            </v-col>
+        </v-row>
+        <v-row v-else>
+            <div class="text-h4">表示することができませんでした。</div>
+        </v-row>
+    </v-container>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+
+export default {
+    name: 'WeatherAreaPage',
+    validate({ params }) {
+        return params.areaId !== undefined && this.$getWeatherInfo(params.areaId) !== undefined;
+    },
+    data() {
+        return {
+            error: {
+                flg: false,
+                title: "エラー",
+                message: null,
+            },
+        }
+    },
+    computed: {
+        ...mapGetters({
+            loadingFlg: 'view/getLoadingFlg',
+            weatherInfo: 'weather/getWeatherInfo',
+        }),
+        weatherAreaInfo() {
+            const areaInfo = this.$getWeatherAreaInfo(this.$route.params.areaId);
+            if (areaInfo === undefined) {
+                return "";
+            } else {
+                return areaInfo.region + " > " + areaInfo.name;
+            }
+        }
+
+    },
+    watch: {
+    },
+    mounted() {
+        this.load();
+    },
+    methods: {
+        ...mapActions({
+            updateLoadingFlg: 'view/updateLoadingFlg',
+            clearWeatherInfo: 'weather/clearWeatherInfo',
+            getWeatherInfo: 'weather/getWeatherInfo',
+        }),
+        load() {
+            this.initError();
+            this.clearWeatherInfo();
+            this.getWeatherInfo(this.$route.params.areaId).catch((err) => {
+                this.setError(err.errorMessage);
+            });
+        },
+        initError() {
+            this.error.flg = false;
+            this.error.message = null;
+        },
+        setError(message) {
+            this.error.flg = true;
+            this.error.message = message;
+        },
+        // 外部サイトを開く
+        apiLink() {
+            window.open("https://www.jma.go.jp/jma/index.html", '_blank');
+        },
+    },
+}
+</script>
+

--- a/pages/weather/area/_areaId.vue
+++ b/pages/weather/area/_areaId.vue
@@ -19,51 +19,8 @@
         <!--  Error発生時 -->
         <my-error-view v-else-if='error.flg' :error-title="error.title" :error-message="error.message" @reload="load">
         </my-error-view>
-        <v-row v-else-if="weatherInfo !== undefined">
-            <!-- -->
-            <v-col v-if="weatherInfo.forecast !== undefined" cols="12" class="my-2">
-                <div class="text-h6">■天気</div>
-                <div class="text-overline"> {{ weatherInfo.forecast.datetime }} 更新</div>
-                <div v-for="areaInfo in weatherInfo.forecast.areas" :key="areaInfo.areaName">
-                    <div class="text-subtitle-1 my-3">●{{ areaInfo.areaName }}</div>
-                    <v-row class="d-flex flex-wrap">
-                        <v-card v-for="weatherInfo in areaInfo.weatherInfos" :key="weatherInfo.date" min-width="300"
-                            max-width="350" class="mx-3 my-3">
-                            <v-card-title>□{{ weatherInfo.date }}</v-card-title>
-                            <v-img v-if="weatherInfo.weatherImageUrl.length > 0" width="100"
-                                :src="weatherInfo.weatherImageUrl">
-                            </v-img>
-                            <v-card-subtitle>{{ weatherInfo.weather }}</v-card-subtitle>
-                            <v-card-text>
-                                <div><strong>・風</strong></div>
-                                <div class="text-body-2">{{ weatherInfo.wind }}</div>
-                                <div><strong>・波</strong></div>
-                                <div class="text-body-2">{{ weatherInfo.wave }}</div>
-                            </v-card-text>
-                        </v-card>
-                    </v-row>
-                </div>
-            </v-col>
-
-            <!-- 概要 -->
-            <v-col v-if="weatherInfo.overview !== undefined" cols="12" class="mx-auto my-2">
-                <div class="text-h6">■天気概要</div>
-                <div class="text-body2"> {{ weatherInfo.overview.text }} </div>
-                <div class="text-overline"> {{ weatherInfo.overview.datetime }} </div>
-            </v-col>
-            <!-- 週間概要 -->
-            <v-col v-if="weatherInfo.overviewWeek !== undefined" cols="12" class="mx-auto my-2">
-                <div class="text-h6">■週間天気予報</div>
-                <div class="text-body2"> {{ weatherInfo.overviewWeek.text }} </div>
-                <div class="text-overline"> {{ weatherInfo.overviewWeek.datetime }} </div>
-            </v-col>
-            <!-- warining -->
-            <v-col v-if="weatherInfo.warning !== undefined" cols="12" class="mx-auto my-2">
-                <div class="text-h6">■注意情報</div>
-                <div class="text-body2"> {{ weatherInfo.warning.text }} </div>
-                <div class="text-overline"> {{ weatherInfo.warning.datetime }} </div>
-            </v-col>
-        </v-row>
+        <my-weather-info-view v-else-if="weatherInfo !== undefined" :weather-info="weatherInfo">
+        </my-weather-info-view>
         <v-row v-else>
             <div class="text-h4">表示することができませんでした。</div>
         </v-row>
@@ -72,9 +29,17 @@
 
 <script>
 import { mapGetters, mapActions } from "vuex";
+import MyErrorView from '~/components/MyErrorView'
+import MyLoadingProgress from '~/components/MyLoadingProgress'
+import MyWeatherInfoView from '~/components/MyWeatherInfoView'
 
 export default {
     name: 'WeatherAreaPage',
+    components: {
+        MyErrorView,
+        MyLoadingProgress,
+        MyWeatherInfoView,
+    },
     validate({ app, params }) {
         return params.areaId !== undefined && app.$getWeatherAreaInfo(params.areaId) !== undefined;
     },

--- a/pages/weather/selectarea.vue
+++ b/pages/weather/selectarea.vue
@@ -1,0 +1,47 @@
+<template>
+    <v-container>
+        <v-row>
+            <v-col>
+                <div class="text-h4 mt-3">天気予報 表示</div>
+                <div class="text-h6 mt-3">「気象庁」の天気予報情報を表示します。エリアを選択してください。</div>
+            </v-col>
+        </v-row>
+        <v-row class="d-flex flex-wrap">
+            <v-card v-for="regionInfo in $weatherConst.areaInfo" :key="regionInfo.region" min-width="300"
+                class="mx-auto my-3">
+                <v-card-title>{{ regionInfo.region }}</v-card-title>
+                <v-card-text>
+                    <ul>
+                        <li v-for="areaInfo in regionInfo.area" :key="areaInfo.id">
+                            <nuxt-link :to="'/weather/area/' + areaInfo.id" no-prefetch>{{
+                                    areaInfo.name
+                            }}</nuxt-link>
+                        </li>
+                    </ul>
+                </v-card-text>
+            </v-card>
+        </v-row>
+    </v-container>
+</template>
+
+<script>
+export default {
+    name: 'WeatherAreaSelectPage',
+    data() {
+        return {
+        }
+    },
+    computed: {
+        areaTitle: {
+
+        }
+    },
+    watch: {
+    },
+    mounted() {
+    },
+    methods: {
+    },
+}
+</script>
+

--- a/plugins/dayformat.js
+++ b/plugins/dayformat.js
@@ -12,6 +12,13 @@ export default ({ app }, inject) => {
         return app.$dayjs(dateString).format('YYYY/MM/DD');
     });
 
+    inject("dateformat_MMDD_ddd", dateString => {
+        if (dateString === null || dateString === undefined) {
+            return '';
+        }
+        return app.$dayjs(dateString).format('MM/DD(ddd)');
+    });
+
     inject("dateformat_YYYYMMDD_widthout_delimiter", dateString => {
         if (dateString === null || dateString === undefined) {
             return '';

--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -1,0 +1,443 @@
+export default ({ app }, inject) => {
+    inject("weatherConst", {
+        areaInfo: [
+            {
+                region: "北海道",
+                centerId: "016000",
+                area: [
+                    {
+                        id: "011000",
+                        name: "宗谷地方",
+                    },
+                    {
+                        id: "012000",
+                        name: "上川・留萌地方",
+                    },
+                    {
+                        id: "013000",
+                        name: "網走・北見・紋別地方",
+                    },
+                    {
+                        id: "014030",
+                        name: "十勝地方",
+                    },
+                    {
+                        id: "014100",
+                        name: "釧路・根室地方",
+                    },
+                    {
+                        id: "015000",
+                        name: "胆振・日高地方",
+                    },
+                    {
+                        id: "016000",
+                        name: "石狩・空知・後志地方",
+                    },
+                    {
+                        id: "017000",
+                        name: "渡島・檜山地方",
+                    },
+                ]
+            },
+            {
+                region: "東北",
+                centerId: "040000",
+                area: [
+                    {
+                        id: "020000",
+                        name: "青森県",
+                    },
+                    {
+                        id: "030000",
+                        name: "岩手県",
+                    },
+                    {
+                        id: "040000",
+                        name: "宮城県",
+                    },
+                    {
+                        id: "050000",
+                        name: "秋田県",
+                    },
+                    {
+                        id: "060000",
+                        name: "山形県",
+                    },
+                    {
+                        id: "070000",
+                        name: "福島県",
+                    },
+                ]
+            },
+            {
+                region: "関東甲信",
+                centerId: "130000",
+                area: [
+                    {
+                        id: "080000",
+                        name: "茨城県",
+                    },
+                    {
+                        id: "090000",
+                        name: "栃木県",
+                    },
+                    {
+                        id: "100000",
+                        name: "群馬県",
+                    },
+                    {
+                        id: "110000",
+                        name: "埼玉県",
+                    },
+                    {
+                        id: "120000",
+                        name: "千葉県",
+                    },
+                    {
+                        id: "130000",
+                        name: "東京都",
+                    },
+                    {
+                        id: "140000",
+                        name: "神奈川県",
+                    },
+                    {
+                        id: "190000",
+                        name: "山梨県",
+                    },
+                    {
+                        id: "200000",
+                        name: "長野県",
+                    },
+                ]
+            },
+            {
+                region: "北陸",
+                centerId: "150000",
+                area: [
+                    {
+                        id: "150000",
+                        name: "新潟県",
+                    },
+                    {
+                        id: "160000",
+                        name: "富山県",
+                    },
+                    {
+                        id: "170000",
+                        name: "石川県",
+                    },
+                    {
+                        id: "180000",
+                        name: "福井県",
+                    },
+                ]
+            },
+            {
+                region: "東海",
+                centerId: "230000",
+                area: [
+                    {
+                        id: "210000",
+                        name: "岐阜県",
+                    },
+                    {
+                        id: "220000",
+                        name: "静岡県",
+                    },
+                    {
+                        id: "230000",
+                        name: "愛知県",
+                    },
+                    {
+                        id: "240000",
+                        name: "三重県",
+                    },
+                ]
+            },
+            {
+                region: "近畿",
+                centerId: "270000",
+                area: [
+                    {
+                        id: "250000",
+                        name: "滋賀県",
+                    },
+                    {
+                        id: "260000",
+                        name: "京都府",
+                    },
+                    {
+                        id: "270000",
+                        name: "大阪府",
+                    },
+                    {
+                        id: "280000",
+                        name: "兵庫県",
+                    },
+                    {
+                        id: "290000",
+                        name: "奈良県",
+                    },
+                    {
+                        id: "300000",
+                        name: "和歌山県",
+                    },
+                ]
+            },
+            {
+                region: "中国（山口は除く）",
+                centerId: "340000",
+                area: [
+                    {
+                        id: "310000",
+                        name: "鳥取県",
+                    },
+                    {
+                        id: "320000",
+                        name: "島根県",
+                    },
+                    {
+                        id: "330000",
+                        name: "岡山県",
+                    },
+                    {
+                        id: "340000",
+                        name: "広島県",
+                    },
+                ]
+            },
+            {
+                region: "四国",
+                centerId: "370000",
+                area: [
+                    {
+                        id: "360000",
+                        name: "徳島県",
+                    },
+                    {
+                        id: "370000",
+                        name: "香川県",
+                    },
+                    {
+                        id: "380000",
+                        name: "愛媛県",
+                    },
+                    {
+                        id: "390000",
+                        name: "高知県",
+                    },
+                ]
+            },
+            {
+                region: "九州北部（山口を含む）",
+                centerId: "400000",
+                area: [
+                    {
+                        id: "350000",
+                        name: "山口県",
+                    },
+                    {
+                        id: "400000",
+                        name: "福岡県",
+                    },
+                    {
+                        id: "410000",
+                        name: "佐賀県",
+                    },
+                    {
+                        id: "420000",
+                        name: "長崎県",
+                    },
+                    {
+                        id: "430000",
+                        name: "熊本県",
+                    },
+                    {
+                        id: "440000",
+                        name: "大分県",
+                    },
+                ]
+            },
+            {
+                region: "九州南部・奄美",
+                centerId: "460100",
+                area: [
+                    {
+                        id: "450000",
+                        name: "宮崎県",
+                    },
+                    {
+                        id: "460100",
+                        name: "鹿児島県（奄美地方除く）",
+                    },
+                    {
+                        id: "460040",
+                        name: "奄美地方",
+                    },
+                ]
+            },
+            {
+                region: "沖縄",
+                centerId: "471000",
+                area: [
+                    {
+                        id: "471000",
+                        name: "沖縄本島地方",
+                    },
+                    {
+                        id: "472000",
+                        name: "大東島地方",
+                    },
+                    {
+                        id: "473000",
+                        name: "宮古島地方",
+                    },
+                    {
+                        id: "474000",
+                        name: "八重島地方",
+                    },
+                ]
+            },
+        ],
+        weatherImageInfo: {
+            100: ["100.svg", "500.svg", "100", "晴", "CLEAR"],
+            101: ["101.svg", "501.svg", "100", "晴時々曇", "PARTLY CLOUDY"],
+            102: ["102.svg", "502.svg", "300", "晴一時雨", "CLEAR, OCCASIONAL SCATTERED SHOWERS"],
+            103: ["102.svg", "502.svg", "300", "晴時々雨", "CLEAR, FREQUENT SCATTERED SHOWERS"],
+            104: ["104.svg", "504.svg", "400", "晴一時雪", "CLEAR, SNOW FLURRIES"],
+            105: ["104.svg", "504.svg", "400", "晴時々雪", "CLEAR, FREQUENT SNOW FLURRIES"],
+            106: ["102.svg", "502.svg", "300", "晴一時雨か雪", "CLEAR, OCCASIONAL SCATTERED SHOWERS OR SNOW FLURRIES"],
+            107: ["102.svg", "502.svg", "300", "晴時々雨か雪", "CLEAR, FREQUENT SCATTERED SHOWERS OR SNOW FLURRIES"],
+            108: ["102.svg", "502.svg", "300", "晴一時雨か雷雨", "CLEAR, OCCASIONAL SCATTERED SHOWERS AND/OR THUNDER"],
+            110: ["110.svg", "510.svg", "100", "晴後時々曇", "CLEAR, PARTLY CLOUDY LATER"],
+            111: ["110.svg", "510.svg", "100", "晴後曇", "CLEAR, CLOUDY LATER"],
+            112: ["112.svg", "512.svg", "300", "晴後一時雨", "CLEAR, OCCASIONAL SCATTERED SHOWERS LATER"],
+            113: ["112.svg", "512.svg", "300", "晴後時々雨", "CLEAR, FREQUENT SCATTERED SHOWERS LATER"],
+            114: ["112.svg", "512.svg", "300", "晴後雨", "CLEAR,RAIN LATER"],
+            115: ["115.svg", "515.svg", "400", "晴後一時雪", "CLEAR, OCCASIONAL SNOW FLURRIES LATER"],
+            116: ["115.svg", "515.svg", "400", "晴後時々雪", "CLEAR, FREQUENT SNOW FLURRIES LATER"],
+            117: ["115.svg", "515.svg", "400", "晴後雪", "CLEAR,SNOW LATER"],
+            118: ["112.svg", "512.svg", "300", "晴後雨か雪", "CLEAR, RAIN OR SNOW LATER"],
+            119: ["112.svg", "512.svg", "300", "晴後雨か雷雨", "CLEAR, RAIN AND/OR THUNDER LATER"],
+            120: ["102.svg", "502.svg", "300", "晴朝夕一時雨", "OCCASIONAL SCATTERED SHOWERS IN THE MORNING AND EVENING, CLEAR DURING THE DAY"],
+            121: ["102.svg", "502.svg", "300", "晴朝の内一時雨", "OCCASIONAL SCATTERED SHOWERS IN THE MORNING, CLEAR DURING THE DAY"],
+            122: ["112.svg", "512.svg", "300", "晴夕方一時雨", "CLEAR, OCCASIONAL SCATTERED SHOWERS IN THE EVENING"],
+            123: ["100.svg", "500.svg", "100", "晴山沿い雷雨", "CLEAR IN THE PLAINS, RAIN AND THUNDER NEAR MOUTAINOUS AREAS"],
+            124: ["100.svg", "500.svg", "100", "晴山沿い雪", "CLEAR IN THE PLAINS, SNOW NEAR MOUTAINOUS AREAS"],
+            125: ["112.svg", "512.svg", "300", "晴午後は雷雨", "CLEAR, RAIN AND THUNDER IN THE AFTERNOON"],
+            126: ["112.svg", "512.svg", "300", "晴昼頃から雨", "CLEAR, RAIN IN THE AFTERNOON"],
+            127: ["112.svg", "512.svg", "300", "晴夕方から雨", "CLEAR, RAIN IN THE EVENING"],
+            128: ["112.svg", "512.svg", "300", "晴夜は雨", "CLEAR, RAIN IN THE NIGHT"],
+            130: ["100.svg", "500.svg", "100", "朝の内霧後晴", "FOG IN THE MORNING, CLEAR LATER"],
+            131: ["100.svg", "500.svg", "100", "晴明け方霧", "FOG AROUND DAWN, CLEAR LATER"],
+            132: ["101.svg", "501.svg", "100", "晴朝夕曇", "CLOUDY IN THE MORNING AND EVENING, CLEAR DURING THE DAY"],
+            140: ["102.svg", "502.svg", "300", "晴時々雨で雷を伴う", "CLEAR, FREQUENT SCATTERED SHOWERS AND THUNDER"],
+            160: ["104.svg", "504.svg", "400", "晴一時雪か雨", "CLEAR, SNOW FLURRIES OR OCCASIONAL SCATTERED SHOWERS"],
+            170: ["104.svg", "504.svg", "400", "晴時々雪か雨", "CLEAR, FREQUENT SNOW FLURRIES OR SCATTERED SHOWERS"],
+            181: ["115.svg", "515.svg", "400", "晴後雪か雨", "CLEAR, SNOW OR RAIN LATER"],
+            200: ["200.svg", "200.svg", "200", "曇", "CLOUDY"],
+            201: ["201.svg", "601.svg", "200", "曇時々晴", "MOSTLY CLOUDY"],
+            202: ["202.svg", "202.svg", "300", "曇一時雨", "CLOUDY, OCCASIONAL SCATTERED SHOWERS"],
+            203: ["202.svg", "202.svg", "300", "曇時々雨", "CLOUDY, FREQUENT SCATTERED SHOWERS"],
+            204: ["204.svg", "204.svg", "400", "曇一時雪", "CLOUDY, OCCASIONAL SNOW FLURRIES"],
+            205: ["204.svg", "204.svg", "400", "曇時々雪", "CLOUDY FREQUENT SNOW FLURRIES"],
+            206: ["202.svg", "202.svg", "300", "曇一時雨か雪", "CLOUDY, OCCASIONAL SCATTERED SHOWERS OR SNOW FLURRIES"],
+            207: ["202.svg", "202.svg", "300", "曇時々雨か雪", "CLOUDY, FREQUENT SCCATERED SHOWERS OR SNOW FLURRIES"],
+            208: ["202.svg", "202.svg", "300", "曇一時雨か雷雨", "CLOUDY, OCCASIONAL SCATTERED SHOWERS AND/OR THUNDER"],
+            209: ["200.svg", "200.svg", "200", "霧", "FOG"],
+            210: ["210.svg", "610.svg", "200", "曇後時々晴", "CLOUDY, PARTLY CLOUDY LATER"],
+            211: ["210.svg", "610.svg", "200", "曇後晴", "CLOUDY, CLEAR LATER"],
+            212: ["212.svg", "212.svg", "300", "曇後一時雨", "CLOUDY, OCCASIONAL SCATTERED SHOWERS LATER"],
+            213: ["212.svg", "212.svg", "300", "曇後時々雨", "CLOUDY, FREQUENT SCATTERED SHOWERS LATER"],
+            214: ["212.svg", "212.svg", "300", "曇後雨", "CLOUDY, RAIN LATER"],
+            215: ["215.svg", "215.svg", "400", "曇後一時雪", "CLOUDY, SNOW FLURRIES LATER"],
+            216: ["215.svg", "215.svg", "400", "曇後時々雪", "CLOUDY, FREQUENT SNOW FLURRIES LATER"],
+            217: ["215.svg", "215.svg", "400", "曇後雪", "CLOUDY, SNOW LATER"],
+            218: ["212.svg", "212.svg", "300", "曇後雨か雪", "CLOUDY, RAIN OR SNOW LATER"],
+            219: ["212.svg", "212.svg", "300", "曇後雨か雷雨", "CLOUDY, RAIN AND/OR THUNDER LATER"],
+            220: ["202.svg", "202.svg", "300", "曇朝夕一時雨", "OCCASIONAL SCCATERED SHOWERS IN THE MORNING AND EVENING, CLOUDY DURING THE DAY"],
+            221: ["202.svg", "202.svg", "300", "曇朝の内一時雨", "CLOUDY OCCASIONAL SCCATERED SHOWERS IN THE MORNING"],
+            222: ["212.svg", "212.svg", "300", "曇夕方一時雨", "CLOUDY, OCCASIONAL SCCATERED SHOWERS IN THE EVENING"],
+            223: ["201.svg", "601.svg", "200", "曇日中時々晴", "CLOUDY IN THE MORNING AND EVENING, PARTLY CLOUDY DURING THE DAY,"],
+            224: ["212.svg", "212.svg", "300", "曇昼頃から雨", "CLOUDY, RAIN IN THE AFTERNOON"],
+            225: ["212.svg", "212.svg", "300", "曇夕方から雨", "CLOUDY, RAIN IN THE EVENING"],
+            226: ["212.svg", "212.svg", "300", "曇夜は雨", "CLOUDY, RAIN IN THE NIGHT"],
+            228: ["215.svg", "215.svg", "400", "曇昼頃から雪", "CLOUDY, SNOW IN THE AFTERNOON"],
+            229: ["215.svg", "215.svg", "400", "曇夕方から雪", "CLOUDY, SNOW IN THE EVENING"],
+            230: ["215.svg", "215.svg", "400", "曇夜は雪", "CLOUDY, SNOW IN THE NIGHT"],
+            231: ["200.svg", "200.svg", "200", "曇海上海岸は霧か霧雨", "CLOUDY, FOG OR DRIZZLING ON THE SEA AND NEAR SEASHORE"],
+            240: ["202.svg", "202.svg", "300", "曇時々雨で雷を伴う", "CLOUDY, FREQUENT SCCATERED SHOWERS AND THUNDER"],
+            250: ["204.svg", "204.svg", "400", "曇時々雪で雷を伴う", "CLOUDY, FREQUENT SNOW AND THUNDER"],
+            260: ["204.svg", "204.svg", "400", "曇一時雪か雨", "CLOUDY, SNOW FLURRIES OR OCCASIONAL SCATTERED SHOWERS"],
+            270: ["204.svg", "204.svg", "400", "曇時々雪か雨", "CLOUDY, FREQUENT SNOW FLURRIES OR SCATTERED SHOWERS"],
+            281: ["215.svg", "215.svg", "400", "曇後雪か雨", "CLOUDY, SNOW OR RAIN LATER"],
+            300: ["300.svg", "300.svg", "300", "雨", "RAIN"],
+            301: ["301.svg", "701.svg", "300", "雨時々晴", "RAIN, PARTLY CLOUDY"],
+            302: ["302.svg", "302.svg", "300", "雨時々止む", "SHOWERS THROUGHOUT THE DAY"],
+            303: ["303.svg", "303.svg", "400", "雨時々雪", "RAIN,FREQUENT SNOW FLURRIES"],
+            304: ["300.svg", "300.svg", "300", "雨か雪", "RAINORSNOW"],
+            306: ["300.svg", "300.svg", "300", "大雨", "HEAVYRAIN"],
+            308: ["308.svg", "308.svg", "300", "雨で暴風を伴う", "RAINSTORM"],
+            309: ["303.svg", "303.svg", "400", "雨一時雪", "RAIN,OCCASIONAL SNOW"],
+            311: ["311.svg", "711.svg", "300", "雨後晴", "RAIN,CLEAR LATER"],
+            313: ["313.svg", "313.svg", "300", "雨後曇", "RAIN,CLOUDY LATER"],
+            314: ["314.svg", "314.svg", "400", "雨後時々雪", "RAIN, FREQUENT SNOW FLURRIES LATER"],
+            315: ["314.svg", "314.svg", "400", "雨後雪", "RAIN,SNOW LATER"],
+            316: ["311.svg", "711.svg", "300", "雨か雪後晴", "RAIN OR SNOW, CLEAR LATER"],
+            317: ["313.svg", "313.svg", "300", "雨か雪後曇", "RAIN OR SNOW, CLOUDY LATER"],
+            320: ["311.svg", "711.svg", "300", "朝の内雨後晴", "RAIN IN THE MORNING, CLEAR LATER"],
+            321: ["313.svg", "313.svg", "300", "朝の内雨後曇", "RAIN IN THE MORNING, CLOUDY LATER"],
+            322: ["303.svg", "303.svg", "400", "雨朝晩一時雪", "OCCASIONAL SNOW IN THE MORNING AND EVENING, RAIN DURING THE DAY"],
+            323: ["311.svg", "711.svg", "300", "雨昼頃から晴", "RAIN, CLEAR IN THE AFTERNOON"],
+            324: ["311.svg", "711.svg", "300", "雨夕方から晴", "RAIN, CLEAR IN THE EVENING"],
+            325: ["311.svg", "711.svg", "300", "雨夜は晴", "RAIN, CLEAR IN THE NIGHT"],
+            326: ["314.svg", "314.svg", "400", "雨夕方から雪", "RAIN, SNOW IN THE EVENING"],
+            327: ["314.svg", "314.svg", "400", "雨夜は雪", "RAIN,SNOW IN THE NIGHT"],
+            328: ["300.svg", "300.svg", "300", "雨一時強く降る", "RAIN, EXPECT OCCASIONAL HEAVY RAINFALL"],
+            329: ["300.svg", "300.svg", "300", "雨一時みぞれ", "RAIN, OCCASIONAL SLEET"],
+            340: ["400.svg", "400.svg", "400", "雪か雨", "SNOWORRAIN"],
+            350: ["300.svg", "300.svg", "300", "雨で雷を伴う", "RAIN AND THUNDER"],
+            361: ["411.svg", "811.svg", "400", "雪か雨後晴", "SNOW OR RAIN, CLEAR LATER"],
+            371: ["413.svg", "413.svg", "400", "雪か雨後曇", "SNOW OR RAIN, CLOUDY LATER"],
+            400: ["400.svg", "400.svg", "400", "雪", "SNOW"],
+            401: ["401.svg", "801.svg", "400", "雪時々晴", "SNOW, FREQUENT CLEAR"],
+            402: ["402.svg", "402.svg", "400", "雪時々止む", "SNOWTHROUGHOUT THE DAY"],
+            403: ["403.svg", "403.svg", "400", "雪時々雨", "SNOW,FREQUENT SCCATERED SHOWERS"],
+            405: ["400.svg", "400.svg", "400", "大雪", "HEAVYSNOW"],
+            406: ["406.svg", "406.svg", "400", "風雪強い", "SNOWSTORM"],
+            407: ["406.svg", "406.svg", "400", "暴風雪", "HEAVYSNOWSTORM"],
+            409: ["403.svg", "403.svg", "400", "雪一時雨", "SNOW, OCCASIONAL SCCATERED SHOWERS"],
+            411: ["411.svg", "811.svg", "400", "雪後晴", "SNOW,CLEAR LATER"],
+            413: ["413.svg", "413.svg", "400", "雪後曇", "SNOW,CLOUDY LATER"],
+            414: ["414.svg", "414.svg", "400", "雪後雨", "SNOW,RAIN LATER"],
+            420: ["411.svg", "811.svg", "400", "朝の内雪後晴", "SNOW IN THE MORNING, CLEAR LATER"],
+            421: ["413.svg", "413.svg", "400", "朝の内雪後曇", "SNOW IN THE MORNING, CLOUDY LATER"],
+            422: ["414.svg", "414.svg", "400", "雪昼頃から雨", "SNOW, RAIN IN THE AFTERNOON"],
+            423: ["414.svg", "414.svg", "400", "雪夕方から雨", "SNOW, RAIN IN THE EVENING"],
+            425: ["400.svg", "400.svg", "400", "雪一時強く降る", "SNOW, EXPECT OCCASIONAL HEAVY SNOWFALL"],
+            426: ["400.svg", "400.svg", "400", "雪後みぞれ", "SNOW, SLEET LATER"],
+            427: ["400.svg", "400.svg", "400", "雪一時みぞれ", "SNOW, OCCASIONAL SLEET"],
+            450: ["400.svg", "400.svg", "400", "雪で雷を伴う", "SNOW AND THUNDER"]
+        }
+    });
+    inject("getWeatherAreaInfo", (id) => {
+        for (const i in app.$weatherConst.areaInfo) {
+            const regionInfo = app.$weatherConst.areaInfo[i];
+            const areaInfo = regionInfo.area.find(element => element.id === id);
+            if (areaInfo !== undefined) {
+                return {
+                    region: regionInfo.region,
+                    centerId: regionInfo.centerId,
+                    id: areaInfo.id,
+                    name: areaInfo.name
+                };
+            }
+        }
+        return undefined;
+    });
+    inject("getWeatherImageUrl", (code) => {
+        const imageInfo = app.$weatherConst.weatherImageInfo[code];
+        return imageInfo === undefined ? "" : "https://www.jma.go.jp/bosai/forecast/img/" + imageInfo[0];
+    });
+}

--- a/store/weather/index.js
+++ b/store/weather/index.js
@@ -1,0 +1,97 @@
+/* eslint-disable object-shorthand */
+const state = () => ({
+    weatherInfo: {}
+});
+
+const mutations = {
+    /**
+     * 
+     **/
+    setWeatherInfo(state, { forecast, overview, overviewWeek, warning }) {
+        const forecastInfo = {
+            datetime: this.$dateformat_YYYYMMDD_hhmmss(forecast[0].reportDatetime),
+            areas: []
+        };
+        const timeDefines = forecast[0].timeSeries[0].timeDefines;
+        for (const i in forecast[0].timeSeries[0].areas) {
+            const areaInfo = forecast[0].timeSeries[0].areas[i];
+            const areaWeatherInfo = {
+                areaName: areaInfo.area.name,
+                weatherInfos: []
+            };
+            for (let i = 0; i < timeDefines.length; i++) {
+                areaWeatherInfo.weatherInfos.push({
+                    date: this.$dateformat_MMDD_ddd(timeDefines[i]),
+                    weatherCode: areaInfo.weatherCodes[i],
+                    weatherImageUrl: this.$getWeatherImageUrl(areaInfo.weatherCodes[i]),
+                    weather: areaInfo.weathers[i],
+                    wind: areaInfo.winds === undefined ? "" : areaInfo.winds[i],
+                    wave: areaInfo.waves === undefined ? "" : areaInfo.waves[i]
+                });
+            }
+            forecastInfo.areas.push(areaWeatherInfo);
+        }
+        const temp = {
+            forecast: forecastInfo,
+            overview: {
+                datetime: this.$dateformat_YYYYMMDD_hhmmss(overview.reportDatetime),
+                text: overview.text,
+            },
+            overviewWeek: {
+                datetime: this.$dateformat_YYYYMMDD_hhmmss(overviewWeek.reportDatetime),
+                text: overviewWeek.text,
+            },
+            warning: {
+                datetime: this.$dateformat_YYYYMMDD_hhmmss(warning.reportDatetime),
+                text: warning.headlineText,
+            }
+        }
+        state.weatherInfo = temp;
+    },
+    clearWeatherInfo(state) {
+        state.weatherInfo = {};
+    }
+};
+
+const getters = {
+    /**
+     * 
+     **/
+    getWeatherInfo(state) {
+        return state.weatherInfo;
+    },
+};
+
+const actions = {
+    clearWeatherInfo({ commit }) {
+        commit('clearWeatherInfo');
+    },
+    /**
+   * Weatherデータを取得する
+   **/
+    async getWeatherInfo({ commit }, areaId) {
+        const areaInfo = this.$getWeatherAreaInfo(areaId);
+        return await Promise.all(
+            [
+                this.$axios.get("/apiWeather/bosai/forecast/data/forecast/" + areaId + ".json"),
+                this.$axios.get("/apiWeather/bosai/forecast/data/overview_forecast/" + areaId + ".json"),
+                this.$axios.get("/apiWeather/bosai/forecast/data/overview_week/" + areaInfo.centerId + ".json"),
+                this.$axios.get("/apiWeather/bosai/warning/data/warning/" + areaId + ".json"),
+            ]
+        ).then(responses => {
+            commit('setWeatherInfo', {
+                forecast: responses[0].data,
+                overview: responses[1].data,
+                overviewWeek: responses[2].data,
+                warning: responses[3].data,
+            });
+        });
+    },
+};
+
+export default {
+    state,
+    mutations,
+    getters,
+    actions,
+}


### PR DESCRIPTION
# 概要
天気予報画面を追加

# 詳細
気象庁から、天気予報情報を取得し、その情報を表示する画面を追加。

# キャプチャ
## TOPページ
<img width="800" alt="スクリーンショット 2022-08-11 20 59 37" src="https://user-images.githubusercontent.com/108524742/184128864-e15a90da-e21f-4185-b891-346ccf0ac8fb.png">

# エリアを選択するページ
<img width="800" alt="スクリーンショット 2022-08-11 20 59 46" src="https://user-images.githubusercontent.com/108524742/184128876-f386c4b8-24ed-407e-8f04-3cf1edd30bc8.png">

# エリアの天気予報情報を表示するページ

<img width="800" alt="スクリーンショット 2022-08-11 20 59 59" src="https://user-images.githubusercontent.com/108524742/184128882-a4c6576d-e5e0-4298-89ef-7822a805f5ff.png">
<img width="800" alt="スクリーンショット 2022-08-11 21 00 10" src="https://user-images.githubusercontent.com/108524742/184128884-bb55f9d8-9c92-4fc6-9981-c6d799057713.png">
